### PR TITLE
Fixes scanning on duplex scanners

### DIFF
--- a/image.go
+++ b/image.go
@@ -86,10 +86,14 @@ func (m *Image) At(x, y int) color.Color {
 }
 
 // ReadImage reads an image from the connection.
-func (c *Conn) ReadImage() (*Image, error) {
-	defer c.Cancel()
+func (c *Conn) ReadImage() (i *Image, err error) {
+	defer func() {
+		if err != nil {
+			c.Cancel()
+		}
+	}()
 
-	m := Image{}
+	i = new(Image)
 	for {
 		f, err := c.ReadFrame()
 		if err != nil {
@@ -97,11 +101,11 @@ func (c *Conn) ReadImage() (*Image, error) {
 		}
 		switch f.Format {
 		case FrameGray, FrameRgb, FrameRed:
-			m.fs[0] = f
+			i.fs[0] = f
 		case FrameGreen:
-			m.fs[1] = f
+			i.fs[1] = f
 		case FrameBlue:
-			m.fs[2] = f
+			i.fs[2] = f
 		default:
 			return nil, fmt.Errorf("unknown frame type %d", f.Format)
 		}
@@ -109,5 +113,5 @@ func (c *Conn) ReadImage() (*Image, error) {
 			break
 		}
 	}
-	return &m, nil
+	return i, nil
 }


### PR DESCRIPTION
Some scanners (e.g. the Fujitsu ScanSnap S1500) scan both sides of a document in a single pass.

The result is that the one operation on a duplex scanner can result in 2 images, if the scanned document is in fact 2-sided. Each image may have on or multiple frames depending on the `Format`, just like in simplex.

Right now, the `ReadImage` function calls `*Conn.Cancel()` every time `*Conn.ReadImage` is invoked. This is safe for a simplex scanner-- but for a duplex scanner, it cancels the operation, losing the second image created by the second side of the document. The result is that each call to `*Conn.ReadImage` returns only the _front side of each document_.

This diff fixes the problem. It is only necessary to call `*Conn.Cancel` if an error was encountered (in which case it is acceptable that the second side is lost). This way, `*Conn.ReadImage` can be invoked multiple times; once for the front, and once for the back (if any).